### PR TITLE
only update envvar listeners on real changes

### DIFF
--- a/pkg/etcdenvvar/envvarcontroller.go
+++ b/pkg/etcdenvvar/envvarcontroller.go
@@ -168,14 +168,21 @@ func (c *EnvVarController) checkEnvVars() error {
 	if err != nil {
 		return err
 	}
+
+	updated := false
 	func() {
 		c.envVarMapLock.Lock()
 		defer c.envVarMapLock.Unlock()
 
 		if !reflect.DeepEqual(c.envVarMap, currEnvVarMap) {
 			c.envVarMap = currEnvVarMap
+			updated = true
 		}
 	}()
+
+	if !updated {
+		return nil
+	}
 
 	// update listeners outside the lock in-case they are synchronously retrieving via GetEnvVars within the listener
 	for _, listener := range c.listeners {


### PR DESCRIPTION
While reviewing the changes in the backup PR, I've seen that I've introduced unnecessary listener updates during the lock refactoring two years ago.

This PR ensures we return early when the envvars has not changed.